### PR TITLE
Create endpoint for gpp criteria analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Maven and Java
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+*.log
+*.class
+*.jar
+*.war
+*.ear
+
+# IDEs and editors
+/.idea/
+/.vscode/
+/*.iml
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Others
+*.swp
+*.swo

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.0</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
+		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>it.polimi.gpplib</groupId>
 	<artifactId>eforms-gpp-service</artifactId>
@@ -54,6 +55,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>it.polimi.gpplib</groupId>
+			<artifactId>eforms-gpp-library</artifactId>
+			<version>1.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/DummyController.java
+++ b/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/DummyController.java
@@ -1,0 +1,25 @@
+package it.polimi.gpplib.eforms_gpp_service.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import lombok.extern.slf4j.Slf4j;
+import it.polimi.gpplib.DefaultGppNoticeAnalyzer;
+import it.polimi.gpplib.GppNoticeAnalyzer;
+import it.polimi.gpplib.model.Notice;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1")
+public class DummyController {
+    @GetMapping("/unicorn")
+    public String unicorn() {
+        log.info("Unicorn endpoint was called");
+
+        // Notice notice = new Notice(null);
+
+        // GppNoticeAnalyzer analyzer = new DefaultGppNoticeAnalyzer();
+
+        return "🦄 This is the unicorn endpoint!";
+    }
+}

--- a/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/GppController.java
+++ b/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/GppController.java
@@ -1,0 +1,27 @@
+package it.polimi.gpplib.eforms_gpp_service.controller;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.http.MediaType;
+import lombok.extern.slf4j.Slf4j;
+import it.polimi.gpplib.DefaultGppNoticeAnalyzer;
+import it.polimi.gpplib.GppNoticeAnalyzer;
+import it.polimi.gpplib.model.Notice;
+import it.polimi.gpplib.model.GppAnalysisResult;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1")
+public class GppController {
+
+    private final GppNoticeAnalyzer analyzer = new DefaultGppNoticeAnalyzer();
+
+    @PostMapping(value = "/analyze-notice", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GppAnalysisResult> analyzeNotice(@RequestBody String xmlString) {
+        log.info("Received analyze request");
+        Notice notice = analyzer.loadNotice(xmlString);
+        GppAnalysisResult result = analyzer.analyzeNotice(notice);
+        return ResponseEntity.ok(result);
+    }
+}


### PR DESCRIPTION
closes #2

## Description

This PR sets up the controller and adds the endpoint `/analyze-notice` that takes in an xml string representing the notice, and returns a json body with the relevant GPP documents and relevant GPP criteria.

It uses the `eforms-gpp-library`.

In the future the request body might be changed to json, but for now it works as is.