### PR TITLE
Create suggest-patches & apply-patches endpoints

### DIFF
--- a/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/GppController.java
+++ b/src/main/java/it/polimi/gpplib/eforms_gpp_service/controller/GppController.java
@@ -2,13 +2,16 @@ package it.polimi.gpplib.eforms_gpp_service.controller;
 
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.http.MediaType;
 import lombok.extern.slf4j.Slf4j;
 import it.polimi.gpplib.DefaultGppNoticeAnalyzer;
 import it.polimi.gpplib.GppNoticeAnalyzer;
 import it.polimi.gpplib.model.Notice;
 import it.polimi.gpplib.model.GppAnalysisResult;
+import it.polimi.gpplib.model.SuggestedGppCriterion;
+import it.polimi.gpplib.model.SuggestedGppPatch;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -17,11 +20,66 @@ public class GppController {
 
     private final GppNoticeAnalyzer analyzer = new DefaultGppNoticeAnalyzer();
 
+    private Notice dummyNotice;
+
     @PostMapping(value = "/analyze-notice", consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GppAnalysisResult> analyzeNotice(@RequestBody String xmlString) {
         log.info("Received analyze request");
         Notice notice = analyzer.loadNotice(xmlString);
+
+        // ??++ tmp
+        dummyNotice = notice;
+
         GppAnalysisResult result = analyzer.analyzeNotice(notice);
         return ResponseEntity.ok(result);
+    }
+
+    @PostMapping(value = "/suggest-patches", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SuggestedPatchesResponse> suggestPatches(@RequestBody SuggestedPatchesRequest request) {
+        log.info("Received suggest-patches request");
+        // Notice notice = analyzer.loadNotice(request.getNoticeXml());
+
+        // ??++ tmp
+        Notice notice = dummyNotice;
+
+        List<SuggestedGppPatch> patches = analyzer.suggestPatches(notice, request.getCriteria());
+        return ResponseEntity.ok(new SuggestedPatchesResponse(patches));
+    }
+
+    public static class SuggestedPatchesRequest {
+        private String noticeXml;
+        private List<SuggestedGppCriterion> criteria;
+
+        public String getNoticeXml() {
+            return noticeXml;
+        }
+
+        public void setNoticeXml(String noticeXml) {
+            this.noticeXml = noticeXml;
+        }
+
+        public List<SuggestedGppCriterion> getCriteria() {
+            return criteria;
+        }
+
+        public void setCriteria(List<SuggestedGppCriterion> criteria) {
+            this.criteria = criteria;
+        }
+    }
+
+    public static class SuggestedPatchesResponse {
+        private List<SuggestedGppPatch> suggestedPatches;
+
+        public SuggestedPatchesResponse(List<SuggestedGppPatch> patches) {
+            this.suggestedPatches = patches;
+        }
+
+        public List<SuggestedGppPatch> getSuggestedPatches() {
+            return suggestedPatches;
+        }
+
+        public void setSuggestedPatches(List<SuggestedGppPatch> patches) {
+            this.suggestedPatches = patches;
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=eforms-gpp-service
+server.port=4420

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=eforms-gpp-service
+server.port=4420


### PR DESCRIPTION
closes #3 

## Description

This PR adds two new endpoints that wrap the functionality of the `eforms-gpp-library`:
- /suggest-patches
- /apply-patches

It also added a `manualTesting` query parameter to ease testing from Postman.